### PR TITLE
BagFix varchar primery_key

### DIFF
--- a/assets/js/jquery.sortable.gridview.js
+++ b/assets/js/jquery.sortable.gridview.js
@@ -12,7 +12,7 @@
 
         var initialIndex = [];
         $('tr', grid).each(function () {
-            initialIndex.push(JSON.stringify($(this).data('key')));
+            initialIndex.push($(this).data('key'));
         });
 
         grid.sortable({
@@ -21,7 +21,7 @@
                 var items = {};
                 var i = 0;
                 $('tr', grid).each(function () {
-                    var currentKey = JSON.stringify($(this).data('key'));
+                    var currentKey = $(this).data('key');
                     if (initialIndex[i] != currentKey) {
                         items[currentKey] = initialIndex[i];
                         initialIndex[i] = currentKey;


### PR DESCRIPTION
JSON.stringify() экранирует все data-key и отправляет на сервер
``` items:{"\"5465fe1f5da14\"":"\"5465fe5befdf9\"","\"5465fe5befdf9\"":"\"5465fe1f5da14\""} ```
в результате формируется некорректный SQL запрос 
``` SELECT * FROM `post` WHERE `name`='\"5465fe1f5da14\"' ORDER BY `sort_order` ```

items необходимо преобразовывать в строку только перед отправкой на сервер.