### PR TITLE
Fixed custom SortableGridView id bug

### DIFF
--- a/SortableGridView.php
+++ b/SortableGridView.php
@@ -36,7 +36,7 @@ class SortableGridView extends GridView
     protected function registerWidget()
     {
         $view = $this->getView();
-        $view->registerJs("jQuery('#{$this->id}').SortableGridView('{$this->sortableAction}');");
+        $view->registerJs("jQuery('#{$this->options['id']}').SortableGridView('{$this->sortableAction}');");
         SortableGridAsset::register($view);
     }
 }


### PR DESCRIPTION
If you set and id option to the widget it doesn't work. With this commit I changed the id in the registerWidget function. Now you can set a custom id in the options of SortableGridView widget as you can do with the standard GridView.