### PR TITLE
Support for multiple scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ public function behaviors()
     return [
         'sort' => [
             'class' => SortableGridBehavior::className(),
-            'sortableAttribute' => 'sortOrder'
+            'sortableAttribute' => 'sortOrder',
+            // 'scopeAttribute' => 'parentId'
         ],
     ];
 }
@@ -58,3 +59,8 @@ Usage
 -----
 * Use SortableGridView as standard GridView with `sortableAction` option.
 You can also subscribe to the JS event 'sortableSuccess' generated widget after a successful sorting.
+
+
+Scopes
+------
+Sometimes a table contains sort orders for multiple scopes. For example, a list of filters linked to a specific category. The scopeAttribute can be used to segment the sequence list. New items automatically get the next sort order in the segment.

--- a/SortableGridBehavior.php
+++ b/SortableGridBehavior.php
@@ -22,7 +22,8 @@ use yii\db\ActiveRecord;
  *    return [
  *       'sort' => [
  *           'class' => SortableGridBehavior::className(),
- *           'sortableAttribute' => 'sortOrder'
+ *           'sortableAttribute' => 'sortOrder',
+ *           'scopeAttribute' => null
  *       ],
  *   ];
  * }
@@ -35,6 +36,9 @@ class SortableGridBehavior extends Behavior
 {
     /** @var string database field name for row sorting */
     public $sortableAttribute = 'sortOrder';
+    
+    /** @var string database field name for defining scope */
+    public $scopeAttribute = null;
 
     public function events()
     {
@@ -71,7 +75,19 @@ class SortableGridBehavior extends Behavior
             throw new InvalidConfigException("Invalid sortable attribute `{$this->sortableAttribute}`.");
         }
 
-        $maxOrder = $model->find()->max($model->tableName() . '.' . $this->sortableAttribute);
+        if ($this->scopeAttribute !== null &&
+            !$model->hasAttribute($this->scopeAttribute)) {
+            throw new InvalidConfigException("Invalid scope attribute `{$this->scopeAttribute}`.");
+        }
+        
+        if ($this->scopeAttribute !== null)
+        {
+            $maxOrder = $model->find()->where([$this->scopeAttribute => $model->{$this->scopeAttribute}])->max($model->tableName() . '.' . $this->sortableAttribute);
+        }
+        else
+        {
+            $maxOrder = $model->find()->max($model->tableName() . '.' . $this->sortableAttribute);
+        }
         $model->{$this->sortableAttribute} = $maxOrder + 1;
     }
 }


### PR DESCRIPTION
I've added an option for multiple scopes. This enables the system to handle multiple sort order lists inside one table. For example, a table that contains filters per site, where each site should have it's own sort order.

By default, the system ignores scopes, until you supply a scopeAttribute.
