### PR TITLE
Model agnostic SortableGridAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ public function actions()
 {
     return [
         'sort' => [
-            'class' => SortableGridAction::className(),
-            'modelName' => Model::className(),
+            'class' => SortableGridAction::className()
         ],
     ];
 }
@@ -56,5 +55,21 @@ public function actions()
 
 Usage
 -----
-* Use SortableGridView as standard GridView with `sortableAction` option.
+* Use SortableGridView as standard GridView with `sortableAction` and `modelClass` option.
+```php
+SortableGridView::widget([
+    'sortableAction' => '/site/sort',
+    'modelClass' => '\app\models\Company',
+    'dataProvider' => $dataProvider,
+    'filterModel' => $searchModel,
+    'columns' => [
+        ['class' => 'yii\grid\SerialColumn'],
+
+        'id',
+        'title',
+
+        ['class' => 'yii\grid\ActionColumn'],
+    ],
+]);
+```
 You can also subscribe to the JS event 'sortableSuccess' generated widget after a successful sorting.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public function actions()
 
 Usage
 -----
-* Use SortableGridView as standard GridView with `sortableAction` and `modelClass` option.
+* Use SortableGridView as standard GridView with `sortableAction` and `modelClass` options.
 ```php
 SortableGridView::widget([
     'sortableAction' => '/site/sort',

--- a/SortableGridAction.php
+++ b/SortableGridAction.php
@@ -35,18 +35,20 @@ use yii\web\BadRequestHttpException;
  */
 class SortableGridAction extends Action
 {
-    public $modelName;
-
     public function run()
     {
         if (!$items = Yii::$app->request->post('items')) {
             throw new BadRequestHttpException('Don\'t received POST param `items`.');
         }
+        if (!$class = Yii::$app->request->post('class')) {
+            throw new BadRequestHttpException('Don\'t received POST param `class`.');
+        }
+
         /** @var \yii\db\ActiveRecord $model */
-        $model = new $this->modelName;
+        $model = new $class;
         if (!$model->hasMethod('gridSort')) {
             throw new InvalidConfigException(
-                "Not found right `SortableGridBehavior` behavior in `{$this->modelName}`."
+                "Not found right `SortableGridBehavior` behavior in `{$model}`."
             );
         }
 

--- a/SortableGridView.php
+++ b/SortableGridView.php
@@ -20,6 +20,8 @@ class SortableGridView extends GridView
 {
     /** @var string|array Sort action */
     public $sortableAction = ['sort'];
+    /** @var string Model class name */
+    public $modelClass;
 
     public function init()
     {
@@ -36,7 +38,9 @@ class SortableGridView extends GridView
     protected function registerWidget()
     {
         $view = $this->getView();
-        $view->registerJs("jQuery('#{$this->options['id']}').SortableGridView('{$this->sortableAction}');");
+        $class = str_replace('\\', '\\\\', $this->modelClass);
+        $view->registerJs("jQuery('#{$this->options['id']}').SortableGridView('{$this->sortableAction}',
+                                                                              '{$class}');");
         SortableGridAsset::register($view);
     }
 }

--- a/assets/js/jquery.sortable.gridview.js
+++ b/assets/js/jquery.sortable.gridview.js
@@ -6,7 +6,7 @@
         return ui;
     };
 
-    $.fn.SortableGridView = function (action) {
+    $.fn.SortableGridView = function (action, modelClass) {
         var widget = this;
         var grid = $('tbody', this);
 
@@ -33,7 +33,10 @@
                 $.ajax({
                     'url': action,
                     'type': 'post',
-                    'data': {'items': JSON.stringify(items)},
+                    'data': {
+                        'items': JSON.stringify(items),
+                        'class': modelClass
+                    },
                     'success': function () {
                         widget.trigger('sortableSuccess');
                     },


### PR DESCRIPTION
Suppose that user has more than one sortable model in project. He has to implement SortableGridAction for each model. I think that it is better to have single SortableGridAction implementation in project that handles requests from all sortable grids. 
I removed modelName from SortableGridAction. It will receive class name via ajax. Class name is specified in SortableGridView declaration.
