### PR TITLE
Change query syntax for proper quotation

### DIFF
--- a/SortableGridBehavior.php
+++ b/SortableGridBehavior.php
@@ -82,7 +82,7 @@ class SortableGridBehavior extends Behavior
             call_user_func($this->scope, $query);
         }
 
-        $maxOrder = $query->max($model::tableName() . '.' . $this->sortableAttribute);
+        $maxOrder = $query->max('{{' . $model::tableName() . '}}.[[' . $this->sortableAttribute . ']]');
         $model->{$this->sortableAttribute} = $maxOrder + 1;
     }
 }


### PR DESCRIPTION
I had a problem with SQLite and column named "order". In case it is not properly quoted, it gets an SQL syntax error. Proposed changes is according to this http://www.yiiframework.com/doc-2.0/guide-db-dao.html#quoting-table-and-column-names.
