### PR TITLE
Don't use the table at all in max() query

### DIFF
--- a/SortableGridBehavior.php
+++ b/SortableGridBehavior.php
@@ -89,10 +89,7 @@ class SortableGridBehavior extends Behavior
             call_user_func($this->scope, $query);
         }
 
-        /* Override model alias if defined in the model's class */
-        $query->from([$model::tableName() => $model::tableName()]);
-
-        $maxOrder = $query->max('{{' . trim($model::tableName(), '{}') . '}}.[[' . $this->sortableAttribute . ']]');
+        $maxOrder = $query->max('[[' . $this->sortableAttribute . ']]');
         $model->{$this->sortableAttribute} = $maxOrder + 1;
     }
 }


### PR DESCRIPTION
I'm having an issue with the following scenario:

* I have a single table `thing`
* I have two models Table, Chair extending Thing, and aliasing the table name in find() (resp. `table`, `chair` and adding a condition to the where clause.
 
Currently, the resulting SQL when computing a newly inserted record position is:
```
SELECT MAX(`thing`.`position`) FROM `thing` `chair` WHERE `chair`.`type`="chair"
```

which errors: 

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'thing.position' in 'field list'
```

I cannot override tableName() in my models as the tables wouldn't exist.

I've seen the problem fixed in #30, and I was thinking, do we really need to specify the table name in the fields list? It's more likely to cause troubles than anything?

This PR fixes my problem and should still works for #30 