### PR TITLE
Исправлние ошибки при работе с PostgreSQL.

### DIFF
--- a/SortableGridBehavior.php
+++ b/SortableGridBehavior.php
@@ -90,7 +90,7 @@ class SortableGridBehavior extends Behavior
         }
 
         /* Override model alias if defined in the model's class */
-        $query->from([$model::tableName() => $model::tableName()]);
+        $query->from([$model::tableName()]);
 
         $maxOrder = $query->max('{{' . trim($model::tableName(), '{}') . '}}.[[' . $this->sortableAttribute . ']]');
         $model->{$this->sortableAttribute} = $maxOrder + 1;


### PR DESCRIPTION
Если при работе с PostgreSQL таблица, в которой лежит поле сортировки, находится не в схеме public, то из-за этой строчки (в которой делается неправильная попытка задать алиас для таблицы) скрипт падает при попытке добавить новую строку в таблицу. Потому что неправильно формируется команда вставки - алиас некорректный получается, так как в алиасе не может быть точки, а в этом случае точка будет.